### PR TITLE
Altered heading() and degrees()

### DIFF
--- a/hmc5883l.py
+++ b/hmc5883l.py
@@ -75,12 +75,12 @@ class hmc5883l:
 
         # Convert to degrees from radians
         headingDeg = headingRad * 180 / math.pi
+        return headingDeg
+
+    def degrees(self, (headingDeg)):
         degrees = math.floor(headingDeg)
         minutes = round((headingDeg - degrees) * 60)
         return (degrees, minutes)
-
-    def degrees(self, (degrees, minutes)):
-        return str(degrees) + "°" + str(minutes) + "'"
 
     def __str__(self):
         (x, y, z) = self.axes()


### PR DESCRIPTION
heading() now returns heading in degrees decimal
degrees() now returns degrees minutes

This works better for my project as I am looking for the degrees in numerical format and not a concatenated string.  Perhaps this would work better for others?
